### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -951,7 +951,7 @@ This clears the cache, warms up the cache, and performs a cruicial directory per
 <a name="gotchas" />
  
 [gotchas]: #gotchas
-##Gotchas ##
+## Gotchas  ##
   
 ### namespaced submodules won't work if a base target doesn't exist ###
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
